### PR TITLE
Update opam with angstrom version

### DIFF
--- a/encore.opam
+++ b/encore.opam
@@ -16,7 +16,7 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "angstrom" {> "0.7.0"}
+  "angstrom" {>= "0.9.0"}
   "ocplib-endian"
   "fmt"
   "tls" {test}

--- a/encore.opam
+++ b/encore.opam
@@ -16,7 +16,7 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "angstrom" {> "0.6.0"}
+  "angstrom" {> "0.7.0"}
   "ocplib-endian"
   "fmt"
   "tls" {test}


### PR DESCRIPTION
`Angstrom.take_bigstring_while` was introduced some time later than version 0.7.0. It seems 0.8.0 introduced it.